### PR TITLE
Fix snipe/snipe-it major version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -314,7 +314,7 @@
         "simplito/elliptic-php": "<1.0.6",
         "slim/slim": "<2.6",
         "smarty/smarty": "<3.1.43|>=4,<4.0.3",
-        "snipe/snipe-it": "<= 6.0.0-RC-5|<5.3.11",
+        "snipe/snipe-it": "<5.3.11|>=6,<=6.0.0-RC-5",
         "socalnick/scn-social-auth": "<1.15.2",
         "socialiteproviders/steam": "<1.1",
         "spipu/html2pdf": "<5.2.4",


### PR DESCRIPTION
Looks to be auto-generated in this commit 3bbc1ff6ef5ac9e765a1e4b8464a7ab97e656820

Fixes Original commit: "FriendsOfPHP/security-advisories@017f334"